### PR TITLE
Register per span timer/meter for given method

### DIFF
--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/HoneycombContextualizer.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/HoneycombContextualizer.java
@@ -43,9 +43,9 @@ public class HoneycombContextualizer
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
-    private static ThreadLocal<Span> SPAN = new ThreadLocal<>();
+    private static final ThreadLocal<Span> SPAN = new ThreadLocal<>();
 
-    private static ThreadLocal<SpanContext> SPAN_CONTEXT = new ThreadLocal<>();
+    private static final ThreadLocal<SpanContext> SPAN_CONTEXT = new ThreadLocal<>();
 
     @Inject
     private HoneycombManager honeycombManager;

--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/HoneycombManager.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/HoneycombManager.java
@@ -39,6 +39,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static org.commonjava.o11yphant.metrics.RequestContextHelper.AVERAGE_TIME_MS;
 import static org.commonjava.o11yphant.metrics.RequestContextHelper.CUMULATIVE_COUNTS;
@@ -231,7 +232,7 @@ public class HoneycombManager
         return null;
     }
 
-    public Timer getSpanTimer( String name )
+    public Optional<Timer> getSpanTimer( String name )
     {
         SpanContext spanContext = (SpanContext) honeycombContextualizer.extractCurrentContext();
         if ( spanContext != null )
@@ -242,26 +243,26 @@ public class HoneycombManager
                 timer = new Timer();
                 spanContext.putTimer( name, timer );
             }
-            return timer;
+            return Optional.of( timer );
         }
-        return null;
+        return Optional.empty();
     }
 
-    public Timer.Context startSpanTimer( String name )
+    public Optional<Timer.Context> startSpanTimer( String name )
     {
         SpanContext spanContext = (SpanContext) honeycombContextualizer.extractCurrentContext();
         if ( spanContext != null )
         {
-            Timer timer = getSpanTimer( name );
+            Timer timer = getSpanTimer( name ).get();
             if ( timer != null )
             {
-                return timer.time();
+                return Optional.of( timer.time() );
             }
         }
-        return null;
+        return Optional.empty();
     }
 
-    public Meter getSpanMeter( String name )
+    public Optional<Meter> getSpanMeter( String name )
     {
         SpanContext spanContext = (SpanContext) honeycombContextualizer.extractCurrentContext();
         if ( spanContext != null )
@@ -272,9 +273,9 @@ public class HoneycombManager
                 meter = new Meter();
                 spanContext.putMeter( name, meter );
             }
-            return meter;
+            return Optional.of( meter );
         }
-        return null;
+        return Optional.empty();
     }
 
     public void addSpanField( String name, Object value )

--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/SpanContext.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/SpanContext.java
@@ -15,7 +15,12 @@
  */
 package org.commonjava.o11yphant.honeycomb;
 
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Timer;
 import io.honeycomb.beeline.tracing.Span;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class SpanContext
 {
@@ -23,16 +28,24 @@ public class SpanContext
 
     private final String parentSpanId;
 
-    public SpanContext( final String traceId, final String parentSpanId )
+    private final String spanId;
+
+    private Map<String, Timer> timerMap = new HashMap<>();
+
+    private Map<String, Meter> meterMap = new HashMap<>();
+
+    public SpanContext( final String traceId, final String spanId, final String parentSpanId )
     {
         this.traceId = traceId;
+        this.spanId = spanId;
         this.parentSpanId = parentSpanId;
     }
 
     public SpanContext( final Span span )
     {
         this.traceId = span.getTraceId();
-        this.parentSpanId = span.getSpanId();
+        this.spanId = span.getSpanId();
+        this.parentSpanId = span.getParentSpanId();
     }
 
     public String getParentSpanId()
@@ -45,9 +58,36 @@ public class SpanContext
         return traceId;
     }
 
+    public String getSpanId()
+    {
+        return spanId;
+    }
+
     @Override
     public String toString()
     {
-        return "SpanContext{" + "traceId='" + traceId + '\'' + ", parentSpanId='" + parentSpanId + '\'' + '}';
+        return "SpanContext{" + "traceId='" + traceId + '\'' + ", spanId='" + spanId + '\'' + ", parentSpanId='"
+                        + parentSpanId + '\'' + '}';
     }
+
+    public void putTimer( String timerName, Timer timer )
+    {
+        timerMap.put( timerName, timer );
+    }
+
+    public Timer getTimer( String timerName )
+    {
+        return timerMap.get( timerName );
+    }
+
+    public Meter getMeter( String meterName )
+    {
+        return meterMap.get( meterName );
+    }
+
+    public void putMeter( String meterName, Meter meter )
+    {
+        meterMap.put( meterName, meter );
+    }
+
 }

--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/SpanContext.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/SpanContext.java
@@ -22,6 +22,8 @@ import io.honeycomb.beeline.tracing.Span;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Collections.unmodifiableMap;
+
 public class SpanContext
 {
     private final String traceId;
@@ -90,4 +92,13 @@ public class SpanContext
         meterMap.put( meterName, meter );
     }
 
+    public Map<String, Timer> getTimers()
+    {
+        return unmodifiableMap( timerMap );
+    }
+
+    public Map<String, Meter> getMeters()
+    {
+        return unmodifiableMap( meterMap );
+    }
 }

--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/interceptor/vertical/HoneycombWrapperEndInterceptor.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/interceptor/vertical/HoneycombWrapperEndInterceptor.java
@@ -20,7 +20,6 @@ import io.honeycomb.beeline.tracing.Span;
 import org.commonjava.o11yphant.annotation.MetricWrapper;
 import org.commonjava.o11yphant.honeycomb.HoneycombManager;
 import org.commonjava.o11yphant.honeycomb.config.HoneycombConfiguration;
-import org.commonjava.o11yphant.honeycomb.util.InterceptorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/interceptor/vertical/HoneycombWrapperInterceptor.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/interceptor/vertical/HoneycombWrapperInterceptor.java
@@ -19,7 +19,6 @@ import io.honeycomb.beeline.tracing.Span;
 import org.commonjava.o11yphant.annotation.MetricWrapper;
 import org.commonjava.o11yphant.honeycomb.HoneycombManager;
 import org.commonjava.o11yphant.honeycomb.config.HoneycombConfiguration;
-import org.commonjava.o11yphant.honeycomb.util.InterceptorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/interceptor/vertical/HoneycombWrapperStartInterceptor.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/interceptor/vertical/HoneycombWrapperStartInterceptor.java
@@ -19,7 +19,6 @@ import io.honeycomb.beeline.tracing.Span;
 import org.commonjava.o11yphant.annotation.MetricWrapperStart;
 import org.commonjava.o11yphant.honeycomb.HoneycombManager;
 import org.commonjava.o11yphant.honeycomb.config.HoneycombConfiguration;
-import org.commonjava.o11yphant.honeycomb.util.InterceptorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/metrics/core/src/main/java/org/commonjava/o11yphant/conf/MetricsConfig.java
+++ b/metrics/core/src/main/java/org/commonjava/o11yphant/conf/MetricsConfig.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.o11yphant.conf;
+
+public interface MetricsConfig
+{
+    String getNodePrefix();
+}

--- a/metrics/core/src/main/java/org/commonjava/o11yphant/metrics/MetricsManager.java
+++ b/metrics/core/src/main/java/org/commonjava/o11yphant/metrics/MetricsManager.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.o11yphant.metrics;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import org.commonjava.cdi.util.weft.ThreadContext;
+import org.commonjava.o11yphant.conf.MetricsConfig;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public interface MetricsManager
+{
+    HealthCheckRegistry getHealthCheckRegistry();
+
+    boolean isMetered( Supplier<Boolean> meteringOverride );
+
+    Timer.Context startTimer( String name );
+
+    long stopTimer( String name );
+
+    Meter getMeter( String name );
+
+    void accumulate( String name, final double elapsed );
+
+    <T> T wrapWithStandardMetrics( final Supplier<T> method, final Supplier<String> classifier );
+
+    boolean checkMetered();
+
+    boolean checkMetered( ThreadContext ctx );
+
+    void stopTimers( final Map<String, Timer.Context> timers );
+
+    void mark( final Collection<String> metricNames );
+
+    void addGauges( Class<?> className, String method, Map<String, Gauge<Integer>> gauges );
+
+    MetricRegistry getMetricRegistry();
+
+    MetricsConfig getConfig();
+}


### PR DESCRIPTION
As described in MMENG-452, it supports:
- Register new field values for the current span
- Register a Timer for a given method, which will accumulate call stats for the current span
- Register a Meter for a given method, which will accumulate marks for the current span