### PR TITLE
Support RootSpanFields

### DIFF
--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/HoneycombManager.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/HoneycombManager.java
@@ -108,6 +108,14 @@ public class HoneycombManager
         }
     }
 
+    /**
+     * Register new {@link RootSpanFields} instances in case CDI is not available in client library.
+     */
+    public void registerRootSpanFields( RootSpanFields rootSpanFields )
+    {
+        rootSpanFieldsList.add( rootSpanFields );
+    }
+
     public HoneyClient getClient()
     {
         return client;

--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/RootSpanFields.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/RootSpanFields.java
@@ -1,0 +1,12 @@
+package org.commonjava.o11yphant.honeycomb;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * These are to be injected into root spans for a node (not necessarily restricted to the first span in a trace,
+ * more like the first span in a service). RootSpanFields instances should be iterated with the root span when a service is finished executing (or on error!).
+ */
+public interface RootSpanFields extends Supplier<Map<String,Object>>
+{
+}


### PR DESCRIPTION
These are to be injected into root spans for a node (not necessarily restricted to the first span in a trace, more like the first span in a service). RootSpanFields instances should be iterated with the root span when a service is finished executing (or on error!).