### PR TITLE
Selected environment variables are injected to root spans

### DIFF
--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/config/HoneycombConfiguration.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/config/HoneycombConfiguration.java
@@ -55,6 +55,8 @@ public interface HoneycombConfiguration
 
     Set<String> getFieldSet();
 
+    String getEnvironmentMappings();
+
     default int getSampleRate( Method method )
     {
         Logger logger = LoggerFactory.getLogger( getClass() );

--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/impl/EnvRootSpanFields.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/impl/EnvRootSpanFields.java
@@ -1,0 +1,45 @@
+package org.commonjava.o11yphant.honeycomb.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.commonjava.o11yphant.honeycomb.RootSpanFields;
+import org.commonjava.o11yphant.honeycomb.config.HoneycombConfiguration;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Allow configuration of a set of environment variables to extract from the system and add to the Span as fields.
+ */
+@ApplicationScoped
+public class EnvRootSpanFields
+                implements RootSpanFields
+{
+    @Inject
+    private HoneycombConfiguration configuration;
+
+    @Override
+    public Map<String, Object> get()
+    {
+        String environmentMappings = configuration.getEnvironmentMappings();
+
+        String[] mappings = environmentMappings == null ? new String[0] : environmentMappings.split( "\\s*,\\s*" );
+        Map<String, Object> envars = new HashMap<>();
+        Stream.of( mappings ).forEach( kv -> {
+            String[] keyAlias = kv.split( "\\s*=\\s*" );
+            if ( keyAlias.length > 1 )
+            {
+                String value = System.getenv( keyAlias[0].trim() );
+                if ( StringUtils.isEmpty( value ) )
+                {
+                    value = "Unknown";
+                }
+
+                envars.put( keyAlias[1].trim(), value );
+            }
+        } );
+        return envars;
+    }
+}


### PR DESCRIPTION
As mentioned in MMENG-446,
We need to replicate the logic found in org.commonjava.indy.CustomJsonLayout, in Indy, and allow configuration of a set of environment variables to extract from the system and add to the Span as fields.