### PR TITLE
Cassandra connection metrics are injected to root spans

### DIFF
--- a/honeycomb/pom.xml
+++ b/honeycomb/pom.xml
@@ -44,6 +44,10 @@
       <groupId>io.agroal</groupId>
       <artifactId>agroal-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.datastax.cassandra</groupId>
+      <artifactId>cassandra-driver-core</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/impl/CassandraConnectionRootSpanFields.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/impl/CassandraConnectionRootSpanFields.java
@@ -1,0 +1,62 @@
+package org.commonjava.o11yphant.honeycomb.impl;
+
+import com.datastax.driver.core.Host;
+import com.datastax.driver.core.Session;
+import org.commonjava.o11yphant.honeycomb.RootSpanFields;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static org.commonjava.o11yphant.metrics.util.NameUtils.name;
+
+/**
+ * Allow an application to register a new RootSpanFields implementation for any Cassandra connection pool it sets up.
+ */
+public abstract class CassandraConnectionRootSpanFields
+                implements RootSpanFields
+{
+    /**
+     * Get cassandra sessions, each with a name (usually it is the keyspace name).
+     */
+    protected abstract Map<String, Session> getSessions();
+
+    private Map<String, Session> sessions;
+
+    public CassandraConnectionRootSpanFields()
+    {
+        this.sessions = getSessions();
+    }
+
+    public CassandraConnectionRootSpanFields( Map<String, Session> sessions )
+    {
+        this.sessions = sessions;
+    }
+
+    @Override
+    public Map<String, Object> get()
+    {
+        if ( sessions == null || sessions.isEmpty() )
+        {
+            return emptyMap();
+        }
+
+        Map<String, Object> ret = new HashMap<>();
+        sessions.forEach( ( sessionName, session ) -> {
+            Session.State st = session.getState(); // a snapshot of the state of this session
+            Collection<Host> hosts = st.getConnectedHosts();
+            hosts.forEach( host -> {
+                String hostname = host.getAddress().getHostName();
+                int open = st.getOpenConnections( host );
+                int trashed = st.getTrashedConnections( host );
+                int total = open + trashed;
+                String prefix = name( "cassandra", sessionName );
+                ret.put( name( prefix, hostname, "totalConnections" ), total );
+                ret.put( name( prefix, hostname, "openConnections" ), open );
+                ret.put( name( prefix, hostname, "trashedConnections" ), trashed );
+            } );
+        } );
+        return ret;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <undertowVersion>2.1.0.Final</undertowVersion>
         <weftVersion>1.16</weftVersion>
         <agroalVersion>1.8</agroalVersion>
+        <datastaxVersion>3.7.2</datastaxVersion>
     </properties>
 
     <dependencyManagement>
@@ -180,6 +181,12 @@
                 <groupId>io.agroal</groupId>
                 <artifactId>agroal-api</artifactId>
                 <version>${agroalVersion}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.datastax.cassandra</groupId>
+                <artifactId>cassandra-driver-core</artifactId>
+                <version>${datastaxVersion}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Allow an application to register a new RootSpanFields implementation for any Cassandra connection pool it sets up.