### PR TITLE
Support withStandardMetricWrapper

### DIFF
--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/interceptor/flat/FlatHoneycombWrapperEndInterceptor.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/interceptor/flat/FlatHoneycombWrapperEndInterceptor.java
@@ -28,7 +28,7 @@ import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 
 import static java.lang.System.currentTimeMillis;
-import static org.commonjava.o11yphant.honeycomb.util.InterceptorUtils.getMetricNameFromParam;
+import static org.commonjava.o11yphant.honeycomb.util.InterceptorUtils.getMetricNameFromContext;
 import static org.commonjava.o11yphant.metrics.MetricsConstants.SKIP_METRIC;
 
 @Interceptor
@@ -46,7 +46,7 @@ public class FlatHoneycombWrapperEndInterceptor
     @AroundInvoke
     public Object operation( InvocationContext context ) throws Exception
     {
-        String name = getMetricNameFromParam( context );
+        String name = getMetricNameFromContext( context );
         logger.trace( "START: Honeycomb metrics-end wrapper: {}", name );
         if ( !config.isEnabled() )
         {

--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/interceptor/flat/FlatHoneycombWrapperInterceptor.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/interceptor/flat/FlatHoneycombWrapperInterceptor.java
@@ -28,8 +28,10 @@ import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 
 import static java.lang.System.currentTimeMillis;
-import static org.commonjava.o11yphant.honeycomb.util.InterceptorUtils.getMetricNameFromParam;
+import static org.commonjava.o11yphant.honeycomb.util.InterceptorUtils.getMetricNameFromContextAfterRun;
+import static org.commonjava.o11yphant.honeycomb.util.InterceptorUtils.getMetricNameFromContext;
 import static org.commonjava.o11yphant.metrics.MetricsConstants.SKIP_METRIC;
+import static org.commonjava.o11yphant.metrics.util.NameUtils.name;
 
 @Interceptor
 @MetricWrapper
@@ -46,7 +48,7 @@ public class FlatHoneycombWrapperInterceptor
     @AroundInvoke
     public Object operation( InvocationContext context ) throws Exception
     {
-        String name = getMetricNameFromParam( context );
+        String name = getMetricNameFromContext( context );
         logger.debug( "START: Honeycomb lambda wrapper: {}", name );
         if ( !config.isEnabled() )
         {
@@ -72,6 +74,7 @@ public class FlatHoneycombWrapperInterceptor
             if ( span != null )
             {
                 long elapse = currentTimeMillis() - begin;
+                name = name( name, getMetricNameFromContextAfterRun( context ) );
                 honeycombManager.addCumulativeField( span, name, elapse );
             }
             logger.debug( "END: Honeycomb lambda wrapper: {}", name );

--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/interceptor/flat/FlatHoneycombWrapperStartInterceptor.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/interceptor/flat/FlatHoneycombWrapperStartInterceptor.java
@@ -28,7 +28,7 @@ import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 
 import static java.lang.System.currentTimeMillis;
-import static org.commonjava.o11yphant.honeycomb.util.InterceptorUtils.getMetricNameFromParam;
+import static org.commonjava.o11yphant.honeycomb.util.InterceptorUtils.getMetricNameFromContext;
 import static org.commonjava.o11yphant.metrics.MetricsConstants.SKIP_METRIC;
 
 @Interceptor
@@ -46,7 +46,7 @@ public class FlatHoneycombWrapperStartInterceptor
     @AroundInvoke
     public Object operation( InvocationContext context ) throws Exception
     {
-        String name = getMetricNameFromParam( context );
+        String name = getMetricNameFromContext( context );
         logger.trace( "START: Honeycomb metrics-start wrapper: {}", name );
         if ( !config.isEnabled() )
         {

--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/interceptor/vertical/HoneycombWrapperEndInterceptor.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/interceptor/vertical/HoneycombWrapperEndInterceptor.java
@@ -28,7 +28,7 @@ import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 
-import static org.commonjava.o11yphant.honeycomb.util.InterceptorUtils.getMetricNameFromParam;
+import static org.commonjava.o11yphant.honeycomb.util.InterceptorUtils.getMetricNameFromContext;
 import static org.commonjava.o11yphant.metrics.MetricsConstants.SKIP_METRIC;
 import static org.commonjava.o11yphant.metrics.RequestContextHelper.getContext;
 
@@ -47,7 +47,7 @@ public class HoneycombWrapperEndInterceptor
     @AroundInvoke
     public Object operation( InvocationContext context ) throws Exception
     {
-        String name = getMetricNameFromParam( context );
+        String name = getMetricNameFromContext( context );
         logger.trace( "START: Honeycomb metrics-end wrapper: {}", name );
         if ( !config.isEnabled() )
         {

--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/interceptor/vertical/HoneycombWrapperInterceptor.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/interceptor/vertical/HoneycombWrapperInterceptor.java
@@ -27,7 +27,7 @@ import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 
-import static org.commonjava.o11yphant.honeycomb.util.InterceptorUtils.getMetricNameFromParam;
+import static org.commonjava.o11yphant.honeycomb.util.InterceptorUtils.getMetricNameFromContext;
 import static org.commonjava.o11yphant.metrics.MetricsConstants.SKIP_METRIC;
 
 @Interceptor
@@ -45,7 +45,7 @@ public class HoneycombWrapperInterceptor
     @AroundInvoke
     public Object operation( InvocationContext context ) throws Exception
     {
-        String name = getMetricNameFromParam( context );
+        String name = getMetricNameFromContext( context );
         logger.debug( "START: Honeycomb lambda wrapper: {}", name );
         if ( !config.isEnabled() )
         {

--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/interceptor/vertical/HoneycombWrapperStartInterceptor.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/interceptor/vertical/HoneycombWrapperStartInterceptor.java
@@ -27,7 +27,7 @@ import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 
-import static org.commonjava.o11yphant.honeycomb.util.InterceptorUtils.getMetricNameFromParam;
+import static org.commonjava.o11yphant.honeycomb.util.InterceptorUtils.getMetricNameFromContext;
 import static org.commonjava.o11yphant.metrics.MetricsConstants.SKIP_METRIC;
 import static org.commonjava.o11yphant.metrics.RequestContextHelper.getContext;
 
@@ -46,7 +46,7 @@ public class HoneycombWrapperStartInterceptor
     @AroundInvoke
     public Object operation( InvocationContext context ) throws Exception
     {
-        String name = getMetricNameFromParam( context );
+        String name = getMetricNameFromContext( context );
         logger.trace( "START: Honeycomb metrics-start wrapper: {}", name );
         if ( !config.isEnabled() )
         {

--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/util/InterceptorUtils.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/util/InterceptorUtils.java
@@ -16,29 +16,41 @@
 package org.commonjava.o11yphant.honeycomb.util;
 
 import org.commonjava.o11yphant.metrics.annotation.MetricWrapperNamed;
+import org.commonjava.o11yphant.metrics.annotation.MetricWrapperNamedAfterRun;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.interceptor.InvocationContext;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.function.Supplier;
 
 public class InterceptorUtils
 {
+    private static Logger logger = LoggerFactory.getLogger( InterceptorUtils.class );
 
     public static final String SAMPLE_OVERRIDE = "honeycomb.sample-override";
 
-    public static String getMetricNameFromParam( InvocationContext context )
+    public static String getMetricNameFromContext( InvocationContext context )
+    {
+        return getMetricNameFromContextInternal( context, MetricWrapperNamed.class );
+    }
+
+    public static String getMetricNameFromContextAfterRun( InvocationContext context )
+    {
+        return getMetricNameFromContextInternal( context, MetricWrapperNamedAfterRun.class );
+    }
+
+    private static String getMetricNameFromContextInternal( InvocationContext context, Class annotationClass )
     {
         String name = null;
-
         Method method = context.getMethod();
         Parameter[] parameters = method.getParameters();
-        for ( int i=0; i<parameters.length; i++)
+        for ( int i = 0; i < parameters.length; i++ )
         {
             Parameter param = parameters[i];
-            MetricWrapperNamed annotation = param.getAnnotation( MetricWrapperNamed.class );
+            Annotation annotation = param.getAnnotation( annotationClass );
             if ( annotation != null )
             {
                 Object pv = context.getParameters()[i];
@@ -54,11 +66,7 @@ public class InterceptorUtils
                 break;
             }
         }
-
-        Logger logger = LoggerFactory.getLogger( InterceptorUtils.class );
-        logger.debug( "Found metric name: {}", name );
-
+        logger.debug( "Found metric name: {}, annotation: {}", name, annotationClass.getSimpleName() );
         return name;
     }
-
 }

--- a/metrics/api/src/main/java/org/commonjava/o11yphant/metrics/MetricsConstants.java
+++ b/metrics/api/src/main/java/org/commonjava/o11yphant/metrics/MetricsConstants.java
@@ -17,12 +17,6 @@ package org.commonjava.o11yphant.metrics;
 
 public class MetricsConstants
 {
-    public static final String METRICS_PHASE = "metrics-phase";
-
-    public static final String PRELIMINARY_METRICS = "preliminary";
-
-    public static final String FINAL_METRICS = "final";
-
     public static final String DEFAULT = "default";
 
     public static final String EXCEPTION = "exception";
@@ -32,6 +26,14 @@ public class MetricsConstants
     public static final String TIMER = "timer";
 
     public static final String SKIP_METRIC = "skip-this-metric";
+
+    public static final String CUMULATIVE_TIMINGS = "cumulative-timings";
+
+    public static final String CUMULATIVE_COUNT = "cumulative-count";
+
+    public static final String AVERAGE_TIME_MS = "avg-time-ms";
+
+    public static final String MAX_TIME_MS = "max-time-ms";
 
     public static final double NANOS_PER_MILLISECOND = 1E6;
 

--- a/metrics/api/src/main/java/org/commonjava/o11yphant/metrics/annotation/MetricWrapperNamedAfterRun.java
+++ b/metrics/api/src/main/java/org/commonjava/o11yphant/metrics/annotation/MetricWrapperNamedAfterRun.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/o11yphant)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.o11yphant.metrics.annotation;
+
+import javax.interceptor.InterceptorBinding;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@InterceptorBinding
+@Target( { PARAMETER } )
+@Retention( RUNTIME )
+public @interface MetricWrapperNamedAfterRun
+{
+}

--- a/metrics/core/src/main/java/org/commonjava/o11yphant/metrics/DefaultMetricsManager.java
+++ b/metrics/core/src/main/java/org/commonjava/o11yphant/metrics/DefaultMetricsManager.java
@@ -46,14 +46,14 @@ import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
+import static org.commonjava.o11yphant.metrics.MetricsConstants.CUMULATIVE_COUNT;
+import static org.commonjava.o11yphant.metrics.MetricsConstants.CUMULATIVE_TIMINGS;
 import static org.commonjava.o11yphant.metrics.MetricsConstants.DEFAULT;
 import static org.commonjava.o11yphant.metrics.MetricsConstants.EXCEPTION;
 import static org.commonjava.o11yphant.metrics.MetricsConstants.NANOS_PER_MILLISECOND;
 import static org.commonjava.o11yphant.metrics.MetricsConstants.SKIP_METRIC;
 import static org.commonjava.o11yphant.metrics.MetricsConstants.TIMER;
 import static org.commonjava.o11yphant.metrics.util.NameUtils.getDefaultName;
-import static org.commonjava.o11yphant.metrics.RequestContextHelper.CUMULATIVE_COUNTS;
-import static org.commonjava.o11yphant.metrics.RequestContextHelper.CUMULATIVE_TIMINGS;
 import static org.commonjava.o11yphant.metrics.RequestContextHelper.IS_METERED;
 import static org.commonjava.o11yphant.metrics.util.HealthCheckUtils.wrap;
 import static org.commonjava.o11yphant.metrics.util.NameUtils.name;
@@ -206,8 +206,8 @@ public class DefaultMetricsManager
 
             timingMap.merge( name, elapsed, ( existingVal, newVal ) -> existingVal + newVal );
 
-            ctx.putIfAbsent( CUMULATIVE_COUNTS, new ConcurrentHashMap<>() );
-            Map<String, Integer> countMap = (Map<String, Integer>) ctx.get( CUMULATIVE_COUNTS );
+            ctx.putIfAbsent( CUMULATIVE_COUNT, new ConcurrentHashMap<>() );
+            Map<String, Integer> countMap = (Map<String, Integer>) ctx.get( CUMULATIVE_COUNT );
 
             countMap.merge( name, 1, ( existingVal, newVal ) -> existingVal + 1 );
         }
@@ -307,4 +307,5 @@ public class DefaultMetricsManager
     {
         return config;
     }
+
 }

--- a/metrics/core/src/main/java/org/commonjava/o11yphant/metrics/RequestContextHelper.java
+++ b/metrics/core/src/main/java/org/commonjava/o11yphant/metrics/RequestContextHelper.java
@@ -178,16 +178,6 @@ public class RequestContextHelper
     @Thread
     public static final String IS_METERED = "is-metered";
 
-    @Thread
-    @MDC
-    public static final String CUMULATIVE_TIMINGS = "cumulative-timings";
-
-    @Thread
-    @MDC
-    public static final String CUMULATIVE_COUNTS = "cumulative-counts";
-
-    public static final String AVERAGE_TIME_MS = "average-time-ms";
-
     // these are well-known values we'll be using in our log aggregation filters
     public static final String REQUEST_PHASE_START = "start";
 


### PR DESCRIPTION
The withStandardMetricWrapper is to wrap up methods that need to send Honeycomb cumulative fields.