### PR TITLE
Support custom TraceIdProvider

### DIFF
--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/CustomTraceIdProvider.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/CustomTraceIdProvider.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2020 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.o11yphant.honeycomb;
+
+import io.honeycomb.beeline.tracing.ids.TraceIdProvider;
+
+public interface CustomTraceIdProvider extends TraceIdProvider
+{
+}

--- a/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/util/TraceIdUtils.java
+++ b/honeycomb/src/main/java/org/commonjava/o11yphant/honeycomb/util/TraceIdUtils.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2020 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.o11yphant.honeycomb.util;
+
+import io.honeycomb.beeline.tracing.ids.TraceIdProvider;
+import io.honeycomb.beeline.tracing.ids.UUIDTraceIdProvider;
+
+public class TraceIdUtils
+{
+    private static final TraceIdProvider ID_PROVIDER = UUIDTraceIdProvider.getInstance();
+
+    public static String getUUIDTraceId()
+    {
+        return ID_PROVIDER.generateId();
+    }
+}

--- a/metrics/core/src/main/java/org/commonjava/o11yphant/metrics/RequestContextHelper.java
+++ b/metrics/core/src/main/java/org/commonjava/o11yphant/metrics/RequestContextHelper.java
@@ -79,15 +79,15 @@ public class RequestContextHelper
 
     @Target( { FIELD } )
     @Retention( SOURCE )
-    private @interface Header{}
+    public @interface Header{}
 
     @Target( { FIELD } )
     @Retention( SOURCE )
-    private @interface MDC{}
+    public @interface MDC{}
 
     @Target( { FIELD } )
     @Retention( SOURCE )
-    private @interface Thread{}
+    public @interface Thread{}
 
     //
 

--- a/metrics/core/src/main/java/org/commonjava/o11yphant/metrics/RequestContextHelper.java
+++ b/metrics/core/src/main/java/org/commonjava/o11yphant/metrics/RequestContextHelper.java
@@ -79,15 +79,15 @@ public class RequestContextHelper
 
     @Target( { FIELD } )
     @Retention( SOURCE )
-    public @interface Header{}
+    private @interface Header{}
 
     @Target( { FIELD } )
     @Retention( SOURCE )
-    public @interface MDC{}
+    private @interface MDC{}
 
     @Target( { FIELD } )
     @Retention( SOURCE )
-    public @interface Thread{}
+    private @interface Thread{}
 
     //
 


### PR DESCRIPTION
This allows indy to specify a custom TraceIdProvider which will produce a traceId same as the perferedId in ThreadContext.