### PR TITLE
Fix CDI initialization of root-span fields and fix root-span field handling for golden signals

### DIFF
--- a/honeycomb/core/src/main/java/org/commonjava/o11yphant/honeycomb/DefaultHoneycombManager.java
+++ b/honeycomb/core/src/main/java/org/commonjava/o11yphant/honeycomb/DefaultHoneycombManager.java
@@ -62,16 +62,20 @@ public class DefaultHoneycombManager
                                     EventPostProcessor defaultEventPostProcessor )
     {
         super( honeycombConfiguration, defaultTraceSampler, defaultTracingContext, defaultEventPostProcessor );
-
-        if ( rootSpanFieldsInstance != null )
-        {
-            rootSpanFieldsInstance.forEach( instance -> rootSpanFieldsList.add( instance ) );
-        }
     }
 
     @PostConstruct
     public void init()
     {
+        logger.debug( "Registering root-span field handlers..." );
+        if ( rootSpanFieldsInstance != null )
+        {
+            rootSpanFieldsInstance.forEach( instance -> {
+                logger.debug( "Registering root-span fields from: {}", instance.getClass().getSimpleName() );
+                rootSpanFieldsList.add( instance );
+            } );
+        }
+
         super.init();
     }
 

--- a/metrics/api/src/main/java/org/commonjava/o11yphant/metrics/RequestContextConstants.java
+++ b/metrics/api/src/main/java/org/commonjava/o11yphant/metrics/RequestContextConstants.java
@@ -132,4 +132,7 @@ public class RequestContextConstants
 
     public static final String REQUEST_PHASE_END = "end";
 
+    @Thread
+    public static final String GOLDEN_SIGNALS_FUNCTIONS = "golden-signals-functions";
+
 }

--- a/metrics/core/src/main/java/org/commonjava/o11yphant/metrics/GoldenSignalsFilter.java
+++ b/metrics/core/src/main/java/org/commonjava/o11yphant/metrics/GoldenSignalsFilter.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.commonjava.o11yphant.metrics.MetricsConstants.NANOS_PER_MILLISECOND;
+import static org.commonjava.o11yphant.metrics.RequestContextConstants.GOLDEN_SIGNALS_FUNCTIONS;
 import static org.commonjava.o11yphant.metrics.RequestContextConstants.REQUEST_LATENCY_MILLIS;
 import static org.commonjava.o11yphant.metrics.RequestContextConstants.REQUEST_LATENCY_NS;
 
@@ -81,6 +82,8 @@ public class GoldenSignalsFilter
                                                 .collect( Collectors.toMap( h -> h, req::getHeader));
         Collection<String> functions = classifier.classifyFunctions( path, req.getMethod(), headers );
         logger.debug( "Get classified golden functions, path: {}, method: {}, functions: {}", path, req.getMethod(), functions );
+
+        RequestContextHelper.setContext( GOLDEN_SIGNALS_FUNCTIONS, functions );
         try
         {
             functions.forEach( function -> metricSet.function( function ).ifPresent(

--- a/metrics/core/src/main/java/org/commonjava/o11yphant/metrics/jaxrs/PrometheusFilteringRegistry.java
+++ b/metrics/core/src/main/java/org/commonjava/o11yphant/metrics/jaxrs/PrometheusFilteringRegistry.java
@@ -24,6 +24,8 @@ import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import org.commonjava.o11yphant.metrics.conf.PrometheusConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.SortedMap;
@@ -33,6 +35,8 @@ import java.util.TreeMap;
 public class PrometheusFilteringRegistry
                 extends MetricRegistry
 {
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
     private final MetricRegistry delegate;
 
     private final PrometheusConfig config;
@@ -118,11 +122,21 @@ public class PrometheusFilteringRegistry
     private <T extends Metric> SortedMap<String, T> filter( Map<String, T> input )
     {
         TreeMap<String, T> result = new TreeMap<>();
+
+        StringBuilder sb = new StringBuilder("Included in Prometheus metrics:\n");
         input.forEach( (k,v)->{
-            if (config.isMetricExpressed(k)){
+            if ( logger.isTraceEnabled() )
+            {
+                sb.append( config.isMetricExpressed( k ) ? "\n+  " : "\n-  " ).append( k );
+            }
+
+            if ( config.isMetricExpressed( k ) )
+            {
                 result.put( k, v );
             }
         } );
+
+        logger.trace( sb.toString() );
         return result;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <javaVersion>1.8</javaVersion>
         <test-forkCount>1</test-forkCount>
         <metricsVersion>4.0.2</metricsVersion>
-        <honeycombVersion>1.1.0</honeycombVersion>
+        <honeycombVersion>1.5.1</honeycombVersion>
         <prometheusVersion>0.7.0</prometheusVersion>
         <zabbixVersion>0.0.2</zabbixVersion>
         <httpTestserverVersion>1.4</httpTestserverVersion>


### PR DESCRIPTION
GoldenSignalsRootSpanFields was iterating all metrics, not just the ones from the TrafficClassifier. This change will rely on GoldenSignalsFilter to classify the traffic and store the function list in ThreadContext, then pull them out and iterate them here to construct the traffic_type field.

DefaultHoneycombManager was trying to init the rootSpan fields provider list during ctor execution, which didn't play well with CDI in the Indy monolith. This change moves that logic to the init() method, which runs @PostConstruct.