### PR TITLE
Improve Prometheus reporting for statistical analysis

### DIFF
--- a/metrics/common/src/main/java/org/commonjava/o11yphant/metrics/sli/GoldenSignalsFunctionMetrics.java
+++ b/metrics/common/src/main/java/org/commonjava/o11yphant/metrics/sli/GoldenSignalsFunctionMetrics.java
@@ -42,8 +42,6 @@ public class GoldenSignalsFunctionMetrics
 
     private final Meter throughput;
 
-    private final Histogram latencyNs;
-
     public GoldenSignalsFunctionMetrics( String name )
     {
         this.name = name;
@@ -51,14 +49,12 @@ public class GoldenSignalsFunctionMetrics
         this.errors = new O11Meter();
         this.throughput = new O11Meter();
         this.latency = new O11Timer();
-        this.latencyNs = new O11Histogram();
     }
 
     public Map<String, Metric> getMetrics()
     {
         Map<String, Metric> metrics = new HashMap<>();
         metrics.put( name + ".latency", latency );
-        metrics.put( name + ".latency_ns", latencyNs );
         metrics.put( name + ".errors", errors );
         metrics.put( name + ".throughput", throughput );
         metrics.put( name + ".load", load );
@@ -69,7 +65,6 @@ public class GoldenSignalsFunctionMetrics
     public GoldenSignalsFunctionMetrics latency( long duration )
     {
         latency.update( duration, TimeUnit.NANOSECONDS );
-        latencyNs.update( duration );
         return this;
     }
 

--- a/metrics/core/src/main/java/org/commonjava/o11yphant/metrics/jaxrs/CodahalePrometheusDeploymentProvider.java
+++ b/metrics/core/src/main/java/org/commonjava/o11yphant/metrics/jaxrs/CodahalePrometheusDeploymentProvider.java
@@ -17,7 +17,6 @@ package org.commonjava.o11yphant.metrics.jaxrs;
 
 import com.codahale.metrics.MetricRegistry;
 import io.prometheus.client.CollectorRegistry;
-import io.prometheus.client.dropwizard.DropwizardExports;
 import io.undertow.servlet.Servlets;
 import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.ServletInfo;
@@ -51,9 +50,8 @@ public class CodahalePrometheusDeploymentProvider implements PrometheusDeploymen
         }
 
         logger.info( "Configuring Prometheus metrics reporter" );
-        CollectorRegistry.defaultRegistry.register( new DropwizardExports(
-                        new PrometheusFilteringRegistry( codahaleMetricRegistry, config.getPrometheusConfig() ),
-                        new PrometheusSampleBuilder( config.getPrometheusConfig().getNodeLabel() ) ) );
+        CollectorRegistry.defaultRegistry.register(
+                        new PromEnhancedStatsAndTimingExports( codahaleMetricRegistry, config.getPrometheusConfig() ) );
 
         final ServletInfo servlet = Servlets.servlet( "prometheus-metrics", LoggingPrometheusServlet.class,
                                                       new ImmediateInstanceFactory<>( new LoggingPrometheusServlet() ) )

--- a/metrics/core/src/main/java/org/commonjava/o11yphant/metrics/jaxrs/PromEnhancedStatsAndTimingExports.java
+++ b/metrics/core/src/main/java/org/commonjava/o11yphant/metrics/jaxrs/PromEnhancedStatsAndTimingExports.java
@@ -1,0 +1,230 @@
+package org.commonjava.o11yphant.metrics.jaxrs;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+import io.prometheus.client.dropwizard.DropwizardExports;
+import org.commonjava.o11yphant.metrics.conf.PrometheusConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+/**
+ * Modified copy of {@link DropwizardExports} that enables exporting mean, standard deviation, sample size in addition
+ * to other metrics.
+ */
+public class PromEnhancedStatsAndTimingExports
+                extends io.prometheus.client.Collector
+                implements io.prometheus.client.Collector.Describable
+
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass().getName() );
+
+    private final PrometheusFilteringRegistry registry;
+
+    private final PrometheusSampleBuilder sampleBuilder;
+
+    public PromEnhancedStatsAndTimingExports( MetricRegistry metricRegistry, PrometheusConfig prometheusConfig )
+    {
+        this.registry = new PrometheusFilteringRegistry( metricRegistry, prometheusConfig );
+        this.sampleBuilder = new PrometheusSampleBuilder( prometheusConfig.getNodeLabel() );
+    }
+
+    private static String getHelpMessage( String metricName, Metric metric )
+    {
+        return String.format( "Generated from Dropwizard metric import (metric=%s, type=%s)", metricName,
+                              metric.getClass().getName() );
+    }
+
+    /**
+     * Export counter as Prometheus <a href="https://prometheus.io/docs/concepts/metric_types/#gauge">Gauge</a>.
+     */
+    MetricFamilySamples fromCounter( String dropwizardName, Counter counter )
+    {
+        MetricFamilySamples.Sample sample = sampleBuilder.createSample( dropwizardName, "", emptyList(), emptyList(),
+                                                                        Long.valueOf( counter.getCount() )
+                                                                            .doubleValue() );
+
+        return new MetricFamilySamples( sample.name, Type.GAUGE, getHelpMessage( dropwizardName, counter ),
+                                        singletonList( sample ) );
+    }
+
+    /**
+     * Export gauge as a prometheus gauge.
+     */
+    MetricFamilySamples fromGauge( String dropwizardName, Gauge<?> gauge )
+    {
+        Object obj = gauge.getValue();
+        double value;
+        if ( obj instanceof Number )
+        {
+            value = ( (Number) obj ).doubleValue();
+        }
+        else if ( obj instanceof Boolean )
+        {
+            value = ( (Boolean) obj ) ? 1 : 0;
+        }
+        else
+        {
+            logger.trace( String.format( "Invalid type for Gauge %s: %s", sanitizeMetricName( dropwizardName ),
+                                         obj == null ? "null" : obj.getClass().getName() ) );
+            return null;
+        }
+        MetricFamilySamples.Sample sample =
+                        sampleBuilder.createSample( dropwizardName, "", emptyList(), emptyList(), value );
+        return new MetricFamilySamples( sample.name, Type.GAUGE, getHelpMessage( dropwizardName, gauge ),
+                                        singletonList( sample ) );
+    }
+
+    /**
+     * Export a histogram snapshot as a prometheus SUMMARY.
+     *
+     * @param dropwizardName metric name.
+     * @param snapshot       the histogram snapshot.
+     * @param count          the total sample count for this snapshot.
+     * @param factor         a factor to apply to histogram values.
+     */
+    MetricFamilySamples fromSnapshotAndCount( String dropwizardName, Snapshot snapshot, long count, double factor,
+                                              String helpMessage, List<MetricFamilySamples.Sample> extraSamples )
+    {
+        List<MetricFamilySamples.Sample> samples = new ArrayList<>();
+        samples.add( sampleBuilder.createSample( dropwizardName, "", singletonList( "quantile" ), singletonList( "0.75" ),
+                                                 snapshot.get75thPercentile() * factor ) );
+
+        samples.add( sampleBuilder.createSample( dropwizardName, "", singletonList( "quantile" ), singletonList( "0.95" ),
+                                                 snapshot.get95thPercentile() * factor ) );
+
+        samples.add( sampleBuilder.createSample( dropwizardName, "", singletonList( "quantile" ), singletonList( "0.99" ),
+                                                 snapshot.get99thPercentile() * factor ) );
+
+        samples.add( sampleBuilder.createSample( dropwizardName, "_raw_mean", emptyList(), emptyList(),
+                                                 snapshot.getMean() ) );
+        
+        samples.add( sampleBuilder.createSample( dropwizardName, "_raw_stdev", emptyList(), emptyList(),
+                                                 snapshot.getStdDev() ) );
+
+        samples.add( sampleBuilder.createSample( dropwizardName, "_count", emptyList(), emptyList(), count ) );
+
+        samples.addAll( extraSamples );
+
+        return new MetricFamilySamples( samples.get( 0 ).name, Type.SUMMARY, helpMessage, samples );
+    }
+
+    /**
+     * Convert histogram snapshot.
+     */
+    MetricFamilySamples fromHistogram( String dropwizardName, Histogram histogram )
+    {
+        return fromSnapshotAndCount( dropwizardName, histogram.getSnapshot(), histogram.getCount(), 1.0,
+                                     getHelpMessage( dropwizardName, histogram ), emptyList() );
+    }
+
+    /**
+     * Export Dropwizard Timer as a histogram. Use TIME_UNIT as time unit.
+     */
+    MetricFamilySamples fromTimer( String dropwizardName, Timer timer )
+    {
+        return fromSnapshotAndCount( dropwizardName, timer.getSnapshot(), timer.getCount(),
+                                     1.0D / TimeUnit.SECONDS.toNanos( 1L ), getHelpMessage( dropwizardName, timer ),
+                                     timerSamples( dropwizardName, timer ) );
+    }
+
+    private List<MetricFamilySamples.Sample> timerSamples( String dropwizardName, Timer timer )
+    {
+        List<MetricFamilySamples.Sample> samples = new ArrayList<>();
+
+        samples.add( sampleBuilder.createSample( dropwizardName, "_rate", singletonList( "mins" ), singletonList( "1" ),
+                                                 timer.getOneMinuteRate() ) );
+
+        samples.add( sampleBuilder.createSample( dropwizardName, "_rate", singletonList( "mins" ), singletonList( "5" ),
+                                                 timer.getFiveMinuteRate() ) );
+
+        samples.add( sampleBuilder.createSample( dropwizardName, "_rate", singletonList( "mins" ), singletonList( "15" ),
+                                                 timer.getFifteenMinuteRate() ) );
+
+        samples.add( sampleBuilder.createSample( dropwizardName, "_mean_rate", emptyList(), emptyList(),
+                                                 timer.getMeanRate() ) );
+
+        return samples;
+    }
+
+    /**
+     * Export a Meter as as prometheus COUNTER.
+     */
+    MetricFamilySamples fromMeter( String dropwizardName, Meter meter )
+    {
+        final MetricFamilySamples.Sample sample =
+                        sampleBuilder.createSample( dropwizardName, "_total", emptyList(), emptyList(),
+                                                    meter.getCount() );
+        return new MetricFamilySamples( sample.name, Type.COUNTER, getHelpMessage( dropwizardName, meter ),
+                                        singletonList( sample ) );
+    }
+
+    @Override
+    public List<MetricFamilySamples> collect()
+    {
+        Map<String, MetricFamilySamples> mfSamplesMap = new HashMap<>();
+
+        for ( SortedMap.Entry<String, Gauge> entry : registry.getGauges().entrySet() )
+        {
+            addToMap( mfSamplesMap, fromGauge( entry.getKey(), entry.getValue() ) );
+        }
+        for ( SortedMap.Entry<String, Counter> entry : registry.getCounters().entrySet() )
+        {
+            addToMap( mfSamplesMap, fromCounter( entry.getKey(), entry.getValue() ) );
+        }
+        for ( SortedMap.Entry<String, Histogram> entry : registry.getHistograms().entrySet() )
+        {
+            addToMap( mfSamplesMap, fromHistogram( entry.getKey(), entry.getValue() ) );
+        }
+        for ( SortedMap.Entry<String, Timer> entry : registry.getTimers().entrySet() )
+        {
+            addToMap( mfSamplesMap, fromTimer( entry.getKey(), entry.getValue() ) );
+        }
+        for ( SortedMap.Entry<String, Meter> entry : registry.getMeters().entrySet() )
+        {
+            addToMap( mfSamplesMap, fromMeter( entry.getKey(), entry.getValue() ) );
+        }
+        return new ArrayList<>( mfSamplesMap.values() );
+    }
+
+    private void addToMap( Map<String, MetricFamilySamples> mfSamplesMap, MetricFamilySamples newMfSamples )
+    {
+        if ( newMfSamples != null )
+        {
+            MetricFamilySamples currentMfSamples = mfSamplesMap.get( newMfSamples.name );
+            if ( currentMfSamples == null )
+            {
+                mfSamplesMap.put( newMfSamples.name, newMfSamples );
+            }
+            else
+            {
+                List<MetricFamilySamples.Sample> samples =
+                                new ArrayList<>( currentMfSamples.samples );
+                samples.addAll( newMfSamples.samples );
+                mfSamplesMap.put( newMfSamples.name, new MetricFamilySamples( newMfSamples.name, currentMfSamples.type,
+                                                                              currentMfSamples.help, samples ) );
+            }
+        }
+    }
+
+    @Override
+    public List<MetricFamilySamples> describe()
+    {
+        return emptyList();
+    }
+}


### PR DESCRIPTION
This change adds prometheus metric lines for `<metric>_raw_mean`, `<metric>_raw_stdev`, in addition to  the existing `<metric>_count`. Taken together, this allows us to do a statistical T-Test (given some baseline mean) and determine whether the measured mean is significantly different from the baseline performance. 

We will still need to implement a small analysis script / program that can interpret the t-test value for some confidence interval to make the final conclusion. This is because the t-test result has to be looked up in a t-distribution table to get the pval, or the probability of rejecting the null hypothesis (that the means are the same). This will also give us a chance to narrow down the set of metrics for which we want to perform this analysis, and to format the result (expressing whether the difference is a **good** or **bad** difference, and whether a test should fail as a result).

One other point we've exposed here: for timers, we're exporting the rate data (m1-rate, m5-rate, m15-rate and mean_rate).

And, for timer metrics, the _raw_mean and _raw_stdev is expressed in the native units of **nanoseconds**. Accordingly, we no longer need the newly introduced latency_ns measurement in the GoldenSignalsFunctionMetrics class.

I've created a copy of DropwizardExports (used to translate Dropwizard metrics into Prometheus samples) in order to make this change.