### PR TITLE
Add option to disable thread pool spans for tracing

### DIFF
--- a/trace/api/src/main/java/org/commonjava/o11yphant/trace/TracerConfiguration.java
+++ b/trace/api/src/main/java/org/commonjava/o11yphant/trace/TracerConfiguration.java
@@ -35,6 +35,10 @@ public interface TracerConfiguration
                     new HashSet<>( Arrays.asList( CONTENT_TRACKING_ID, HTTP_METHOD, HTTP_STATUS, CLIENT_ADDR,
                                                   PATH, PACKAGE_TYPE, REST_ENDPOINT_PATH, REQUEST_LATENCY_MILLIS ) ) );
 
+    default boolean isThreadSpanEnabled(){
+        return true;
+    }
+
     boolean isEnabled();
 
     boolean isConsoleTransport();

--- a/trace/api/src/main/java/org/commonjava/o11yphant/trace/thread/TraceThreadContextualizer.java
+++ b/trace/api/src/main/java/org/commonjava/o11yphant/trace/thread/TraceThreadContextualizer.java
@@ -62,7 +62,7 @@ public class TraceThreadContextualizer<T extends TracerType>
     @Override
     public Object extractCurrentContext()
     {
-        if ( configuration.isEnabled() )
+        if ( configuration.isEnabled() && configuration.isThreadSpanEnabled())
         {
             Optional<SpanAdapter> activeSpan = traceManager.getActiveSpan();
             ThreadedTraceContext ctx = new ThreadedTraceContext( activeSpan );
@@ -75,7 +75,7 @@ public class TraceThreadContextualizer<T extends TracerType>
     @Override
     public void setChildContext( final Object parentContext )
     {
-        if ( configuration.isEnabled() )
+        if ( configuration.isEnabled() && configuration.isThreadSpanEnabled())
         {
             tracingContext.reinitThreadSpans();
             ThreadedTraceContext parentSpanContext = (ThreadedTraceContext) parentContext;
@@ -102,7 +102,7 @@ public class TraceThreadContextualizer<T extends TracerType>
     @SuppressWarnings( "PMD" )
     public void clearContext()
     {
-        if ( configuration.isEnabled() )
+        if ( configuration.isEnabled() && configuration.isThreadSpanEnabled())
         {
             Optional<SpanAdapter> span = SPAN.get();
             if ( span.isPresent() )


### PR DESCRIPTION
  We found that the threa pool span is causing some rate-limit in
  honeycomb. So here we add a flag to easily close it.