### PR TITLE
Add resource attributes adding through config for opentelemetry

### DIFF
--- a/trace/otel/src/main/java/org/commonjava/o11yphant/otel/OtelConfiguration.java
+++ b/trace/otel/src/main/java/org/commonjava/o11yphant/otel/OtelConfiguration.java
@@ -32,7 +32,13 @@ public interface OtelConfiguration
         return "1.0";
     }
 
-    default Map<String, String> getGrpcHeaders(){
+    default Map<String, String> getGrpcHeaders()
+    {
+        return new HashMap<>();
+    }
+
+    default Map<String, String> getResources()
+    {
         return new HashMap<>();
     }
 
@@ -40,4 +46,5 @@ public interface OtelConfiguration
     {
         return DEFAULT_GRPC_URI;
     }
+
 }


### PR DESCRIPTION
In new tracing support, we will use Resource Attributes to specify service name as dataset or some extra attributes like "sampler_ratio", so here added the resource attributes adding support through configurations.