### PR TITLE
Revert "Update the project groupId"

### DIFF
--- a/metrics/api/pom.xml
+++ b/metrics/api/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.commonjava.util.o11yphant</groupId>
+        <groupId>org.commonjava.util</groupId>
         <artifactId>o11yphant-metrics</artifactId>
         <version>1.8-SNAPSHOT</version>
     </parent>

--- a/metrics/common/pom.xml
+++ b/metrics/common/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.commonjava.util.o11yphant</groupId>
+        <groupId>org.commonjava.util</groupId>
         <artifactId>o11yphant-metrics</artifactId>
         <version>1.8-SNAPSHOT</version>
     </parent>
@@ -30,7 +30,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.commonjava.util.o11yphant</groupId>
+            <groupId>org.commonjava.util</groupId>
             <artifactId>o11yphant-metrics-api</artifactId>
         </dependency>
         <dependency>

--- a/metrics/core/pom.xml
+++ b/metrics/core/pom.xml
@@ -18,8 +18,8 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>org.commonjava.util.o11yphant</groupId>
         <artifactId>o11yphant-metrics</artifactId>
+        <groupId>org.commonjava.util</groupId>
         <version>1.8-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -29,11 +29,11 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.commonjava.util.o11yphant</groupId>
+            <groupId>org.commonjava.util</groupId>
             <artifactId>o11yphant-metrics-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.commonjava.util.o11yphant</groupId>
+            <groupId>org.commonjava.util</groupId>
             <artifactId>o11yphant-metrics-common</artifactId>
         </dependency>
 

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -18,8 +18,8 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <groupId>org.commonjava.util.o11yphant</groupId>
-    <artifactId>o11yphant-parent</artifactId>
+    <artifactId>o11yphant</artifactId>
+    <groupId>org.commonjava.util</groupId>
     <version>1.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
         <version>17</version>
     </parent>
 
-    <groupId>org.commonjava.util.o11yphant</groupId>
-    <artifactId>o11yphant-parent</artifactId>
+    <groupId>org.commonjava.util</groupId>
+    <artifactId>o11yphant</artifactId>
     <version>1.8-SNAPSHOT</version>
 
     <packaging>pom</packaging>
@@ -84,58 +84,58 @@
             </dependency>
 
             <dependency>
-                <groupId>org.commonjava.util.o11yphant</groupId>
+                <groupId>org.commonjava.util</groupId>
                 <artifactId>o11yphant-trace-api</artifactId>
                 <version>1.8-SNAPSHOT</version>
             </dependency>
             <dependency>
-                <groupId>org.commonjava.util.o11yphant</groupId>
+                <groupId>org.commonjava.util</groupId>
                 <artifactId>o11yphant-trace-core</artifactId>
                 <version>1.8-SNAPSHOT</version>
             </dependency>
             <dependency>
-                <groupId>org.commonjava.util.o11yphant</groupId>
+                <groupId>org.commonjava.util</groupId>
                 <artifactId>o11yphant-trace-otel</artifactId>
                 <version>1.8-SNAPSHOT</version>
             </dependency>
             <dependency>
-                <groupId>org.commonjava.util.o11yphant</groupId>
+                <groupId>org.commonjava.util</groupId>
                 <artifactId>o11yphant-trace-honeycomb</artifactId>
                 <version>1.8-SNAPSHOT</version>
             </dependency>
             <dependency>
-                <groupId>org.commonjava.util.o11yphant</groupId>
+                <groupId>org.commonjava.util</groupId>
                 <artifactId>o11yphant-trace-helper-servlet</artifactId>
                 <version>1.8-SNAPSHOT</version>
             </dependency>
             <dependency>
-                <groupId>org.commonjava.util.o11yphant</groupId>
+                <groupId>org.commonjava.util</groupId>
                 <artifactId>o11yphant-trace-helper-httpclient</artifactId>
                 <version>1.8-SNAPSHOT</version>
             </dependency>
             <dependency>
-                <groupId>org.commonjava.util.o11yphant</groupId>
+                <groupId>org.commonjava.util</groupId>
                 <artifactId>o11yphant-trace-helper-jhttpc</artifactId>
                 <version>1.8-SNAPSHOT</version>
             </dependency>
 
             <dependency>
-                <groupId>org.commonjava.util.o11yphant</groupId>
+                <groupId>org.commonjava.util</groupId>
                 <artifactId>o11yphant-metrics</artifactId>
                 <version>1.8-SNAPSHOT</version>
             </dependency>
             <dependency>
-                <groupId>org.commonjava.util.o11yphant</groupId>
+                <groupId>org.commonjava.util</groupId>
                 <artifactId>o11yphant-metrics-api</artifactId>
                 <version>1.8-SNAPSHOT</version>
             </dependency>
             <dependency>
-                <groupId>org.commonjava.util.o11yphant</groupId>
+                <groupId>org.commonjava.util</groupId>
                 <artifactId>o11yphant-metrics-common</artifactId>
                 <version>1.8-SNAPSHOT</version>
             </dependency>
             <dependency>
-                <groupId>org.commonjava.util.o11yphant</groupId>
+                <groupId>org.commonjava.util</groupId>
                 <artifactId>o11yphant-metrics-core</artifactId>
                 <version>1.8-SNAPSHOT</version>
             </dependency>

--- a/trace/api/pom.xml
+++ b/trace/api/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.commonjava.util.o11yphant</groupId>
+        <groupId>org.commonjava.util</groupId>
         <artifactId>o11yphant-trace</artifactId>
         <version>1.8-SNAPSHOT</version>
     </parent>
@@ -30,7 +30,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.commonjava.util.o11yphant</groupId>
+            <groupId>org.commonjava.util</groupId>
             <artifactId>o11yphant-metrics-api</artifactId>
         </dependency>
         <dependency>

--- a/trace/core/pom.xml
+++ b/trace/core/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.commonjava.util.o11yphant</groupId>
+        <groupId>org.commonjava.util</groupId>
         <artifactId>o11yphant-trace</artifactId>
         <version>1.8-SNAPSHOT</version>
     </parent>
@@ -30,11 +30,11 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.commonjava.util.o11yphant</groupId>
+            <groupId>org.commonjava.util</groupId>
             <artifactId>o11yphant-trace-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.commonjava.util.o11yphant</groupId>
+            <groupId>org.commonjava.util</groupId>
             <artifactId>o11yphant-metrics-core</artifactId>
         </dependency>
         <dependency>

--- a/trace/helper-httpclient/pom.xml
+++ b/trace/helper-httpclient/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.commonjava.util.o11yphant</groupId>
+        <groupId>org.commonjava.util</groupId>
         <artifactId>o11yphant-trace</artifactId>
         <version>1.8-SNAPSHOT</version>
     </parent>
@@ -30,11 +30,11 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.commonjava.util.o11yphant</groupId>
+            <groupId>org.commonjava.util</groupId>
             <artifactId>o11yphant-trace-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.commonjava.util.o11yphant</groupId>
+            <groupId>org.commonjava.util</groupId>
             <artifactId>o11yphant-metrics-core</artifactId>
         </dependency>
         <dependency>

--- a/trace/helper-jhttpc/pom.xml
+++ b/trace/helper-jhttpc/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.commonjava.util.o11yphant</groupId>
+        <groupId>org.commonjava.util</groupId>
         <artifactId>o11yphant-trace</artifactId>
         <version>1.8-SNAPSHOT</version>
     </parent>
@@ -30,15 +30,15 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.commonjava.util.o11yphant</groupId>
+            <groupId>org.commonjava.util</groupId>
             <artifactId>o11yphant-trace-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.commonjava.util.o11yphant</groupId>
+            <groupId>org.commonjava.util</groupId>
             <artifactId>o11yphant-trace-helper-httpclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.commonjava.util.o11yphant</groupId>
+            <groupId>org.commonjava.util</groupId>
             <artifactId>o11yphant-metrics-core</artifactId>
         </dependency>
         <dependency>

--- a/trace/helper-servlet/pom.xml
+++ b/trace/helper-servlet/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.commonjava.util.o11yphant</groupId>
+        <groupId>org.commonjava.util</groupId>
         <artifactId>o11yphant-trace</artifactId>
         <version>1.8-SNAPSHOT</version>
     </parent>
@@ -30,7 +30,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.commonjava.util.o11yphant</groupId>
+            <groupId>org.commonjava.util</groupId>
             <artifactId>o11yphant-trace-api</artifactId>
         </dependency>
         <dependency>

--- a/trace/honeycomb/pom.xml
+++ b/trace/honeycomb/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.commonjava.util.o11yphant</groupId>
+        <groupId>org.commonjava.util</groupId>
         <artifactId>o11yphant-trace</artifactId>
         <version>1.8-SNAPSHOT</version>
     </parent>
@@ -30,15 +30,15 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.commonjava.util.o11yphant</groupId>
+            <groupId>org.commonjava.util</groupId>
             <artifactId>o11yphant-metrics-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.commonjava.util.o11yphant</groupId>
+            <groupId>org.commonjava.util</groupId>
             <artifactId>o11yphant-metrics-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.commonjava.util.o11yphant</groupId>
+            <groupId>org.commonjava.util</groupId>
             <artifactId>o11yphant-trace-api</artifactId>
         </dependency>
         <dependency>

--- a/trace/otel/pom.xml
+++ b/trace/otel/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.commonjava.util.o11yphant</groupId>
+        <groupId>org.commonjava.util</groupId>
         <artifactId>o11yphant-trace</artifactId>
         <version>1.8-SNAPSHOT</version>
     </parent>
@@ -46,7 +46,7 @@
             <artifactId>opentelemetry-exporter-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.commonjava.util.o11yphant</groupId>
+            <groupId>org.commonjava.util</groupId>
             <artifactId>o11yphant-trace-api</artifactId>
         </dependency>
         <dependency>

--- a/trace/pom.xml
+++ b/trace/pom.xml
@@ -18,8 +18,8 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <groupId>org.commonjava.util.o11yphant</groupId>
-    <artifactId>o11yphant-parent</artifactId>
+    <artifactId>o11yphant</artifactId>
+    <groupId>org.commonjava.util</groupId>
     <version>1.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
This reverts commit 2f292350d4e82c1a71901af1d6d143600e370d12.

Seems our projects has deep dependencies relying on old groupId, so remove this one.