### PR TITLE
Remove wildcard usage for generic type of TraceManager

### DIFF
--- a/trace/core/src/main/java/org/commonjava/o11yphant/trace/interceptor/FlatTraceMeasureInterceptor.java
+++ b/trace/core/src/main/java/org/commonjava/o11yphant/trace/interceptor/FlatTraceMeasureInterceptor.java
@@ -40,8 +40,9 @@ public class FlatTraceMeasureInterceptor
     @Inject
     private TracerConfiguration config;
 
+    @SuppressWarnings( "rawtypes" )
     @Inject
-    private TraceManager<?> traceManager;
+    private TraceManager traceManager;
 
     @AroundInvoke
     public Object operation( InvocationContext context ) throws Exception

--- a/trace/core/src/main/java/org/commonjava/o11yphant/trace/interceptor/FlatTraceWrapperEndInterceptor.java
+++ b/trace/core/src/main/java/org/commonjava/o11yphant/trace/interceptor/FlatTraceWrapperEndInterceptor.java
@@ -42,8 +42,9 @@ public class FlatTraceWrapperEndInterceptor
     @Inject
     private TracerConfiguration config;
 
+    @SuppressWarnings( "rawtypes" )
     @Inject
-    private TraceManager<?> traceManager;
+    private TraceManager traceManager;
 
     @AroundInvoke
     public Object operation( InvocationContext context ) throws Exception

--- a/trace/core/src/main/java/org/commonjava/o11yphant/trace/interceptor/FlatTraceWrapperInterceptor.java
+++ b/trace/core/src/main/java/org/commonjava/o11yphant/trace/interceptor/FlatTraceWrapperInterceptor.java
@@ -42,8 +42,9 @@ public class FlatTraceWrapperInterceptor
     @Inject
     private TracerConfiguration config;
 
+    @SuppressWarnings( "rawtypes" )
     @Inject
-    private TraceManager<?> traceManager;
+    private TraceManager traceManager;
 
     @AroundInvoke
     public Object operation( InvocationContext context ) throws Exception

--- a/trace/core/src/main/java/org/commonjava/o11yphant/trace/interceptor/FlatTraceWrapperStartInterceptor.java
+++ b/trace/core/src/main/java/org/commonjava/o11yphant/trace/interceptor/FlatTraceWrapperStartInterceptor.java
@@ -42,8 +42,9 @@ public class FlatTraceWrapperStartInterceptor
     @Inject
     private TracerConfiguration config;
 
+    @SuppressWarnings( "rawtypes" )
     @Inject
-    private TraceManager<?> traceManager;
+    private TraceManager traceManager;
 
     @AroundInvoke
     public Object operation( InvocationContext context ) throws Exception

--- a/trace/helper-jhttpc/src/main/java/org/commonjava/o11yphant/jhttpc/SpanningHttpFactory.java
+++ b/trace/helper-jhttpc/src/main/java/org/commonjava/o11yphant/jhttpc/SpanningHttpFactory.java
@@ -29,14 +29,15 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
+@SuppressWarnings( "rawtypes" )
 public class SpanningHttpFactory
                 implements HttpFactoryIfc
 {
     private final HttpFactory delegate;
 
-    private final Optional<TraceManager<?>> traceManager;
+    private final Optional<TraceManager> traceManager;
 
-    public SpanningHttpFactory( HttpFactory httpFactory, Optional<TraceManager<?>> traceManager )
+    public SpanningHttpFactory( HttpFactory httpFactory, Optional<TraceManager> traceManager )
     {
         super();
         delegate = httpFactory;

--- a/trace/helper-jhttpc/src/main/java/org/commonjava/o11yphant/jhttpc/TracerHttpClient.java
+++ b/trace/helper-jhttpc/src/main/java/org/commonjava/o11yphant/jhttpc/TracerHttpClient.java
@@ -34,16 +34,17 @@ import java.util.Optional;
 import static org.commonjava.o11yphant.trace.TraceManager.addFieldToActiveSpan;
 import static org.commonjava.o11yphant.trace.httpclient.HttpClientTools.contextInjector;
 
+@SuppressWarnings( "rawtypes" )
 public class TracerHttpClient
                 extends CloseableHttpClient
 {
     private final CloseableHttpClient delegate;
 
-    private final Optional<TraceManager<?>> traceManager;
+    private final Optional<TraceManager> traceManager;
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
-    public TracerHttpClient( CloseableHttpClient delegate, Optional<TraceManager<?>> traceManager )
+    public TracerHttpClient( CloseableHttpClient delegate, Optional<TraceManager> traceManager )
     {
         this.traceManager = traceManager;
         this.delegate = delegate;

--- a/trace/helper-servlet/src/main/java/org/commonjava/o11yphant/trace/servlet/TraceFilter.java
+++ b/trace/helper-servlet/src/main/java/org/commonjava/o11yphant/trace/servlet/TraceFilter.java
@@ -41,8 +41,9 @@ import static org.commonjava.o11yphant.trace.servlet.ServletContextTools.context
 public class TraceFilter
                 implements Filter
 {
+    @SuppressWarnings( "rawtypes" )
     @Inject
-    private TraceManager<?> traceManager;
+    private TraceManager traceManager;
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 


### PR DESCRIPTION
  Seems CDI producer refuse to create wildcard generic types, which will
  break some tests in galley.