### PR TITLE
Make client span use active span as parent

### DIFF
--- a/trace/api/src/main/java/org/commonjava/o11yphant/trace/impl/SpanWrapper.java
+++ b/trace/api/src/main/java/org/commonjava/o11yphant/trace/impl/SpanWrapper.java
@@ -16,8 +16,10 @@
 package org.commonjava.o11yphant.trace.impl;
 
 import org.commonjava.o11yphant.trace.spi.adapter.SpanAdapter;
+import org.commonjava.o11yphant.trace.spi.adapter.SpanContext;
 
 import java.util.Map;
+import java.util.Optional;
 
 public abstract class SpanWrapper
                 implements SpanAdapter
@@ -108,5 +110,9 @@ public abstract class SpanWrapper
     public String toString()
     {
         return getClass().getSimpleName() + "(" + getDelegate().toString() + ")";
+    }
+
+    public Optional<SpanContext> getSpanContext(){
+        return delegate.getSpanContext();
     }
 }

--- a/trace/api/src/main/java/org/commonjava/o11yphant/trace/spi/SpanProvider.java
+++ b/trace/api/src/main/java/org/commonjava/o11yphant/trace/spi/SpanProvider.java
@@ -27,4 +27,6 @@ public interface SpanProvider
     SpanAdapter startChildSpan( String spanName, Optional<SpanContext> parentContext );
 
     SpanAdapter startClientSpan( String spanName );
+
+    SpanAdapter startClientSpan( String spanName, Optional<SpanContext> parentContext);
 }

--- a/trace/api/src/main/java/org/commonjava/o11yphant/trace/spi/adapter/SpanAdapter.java
+++ b/trace/api/src/main/java/org/commonjava/o11yphant/trace/spi/adapter/SpanAdapter.java
@@ -16,6 +16,7 @@
 package org.commonjava.o11yphant.trace.spi.adapter;
 
 import java.util.Map;
+import java.util.Optional;
 
 public interface SpanAdapter
 {
@@ -50,5 +51,7 @@ public interface SpanAdapter
     void clearInProgressField( String key );
 
     Map<String, Double> getInProgressFields();
+
+    Optional<SpanContext> getSpanContext();
 
 }

--- a/trace/core/src/test/java/org/commonjava/o11yphant/trace/impl/MockSpan.java
+++ b/trace/core/src/test/java/org/commonjava/o11yphant/trace/impl/MockSpan.java
@@ -16,12 +16,14 @@
 package org.commonjava.o11yphant.trace.impl;
 
 import org.commonjava.o11yphant.trace.spi.adapter.SpanAdapter;
+import org.commonjava.o11yphant.trace.spi.adapter.SpanContext;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public class MockSpan
-    implements SpanAdapter
+        implements SpanAdapter
 {
     private boolean isLocalRoot;
 
@@ -102,7 +104,7 @@ public class MockSpan
     @Override
     public Double getInProgressField( String key, Double defValue )
     {
-        return inProgress.getOrDefault( key, defValue);
+        return inProgress.getOrDefault( key, defValue );
     }
 
     @Override
@@ -124,5 +126,11 @@ public class MockSpan
     public Map<String, Double> getInProgressFields()
     {
         return inProgress;
+    }
+
+    @Override
+    public Optional<SpanContext> getSpanContext()
+    {
+        return Optional.empty();
     }
 }

--- a/trace/otel/src/main/java/org/commonjava/o11yphant/otel/impl/OtelSpanProvider.java
+++ b/trace/otel/src/main/java/org/commonjava/o11yphant/otel/impl/OtelSpanProvider.java
@@ -26,15 +26,19 @@ import org.commonjava.o11yphant.otel.impl.adapter.OtelSpanContext;
 import org.commonjava.o11yphant.trace.spi.SpanProvider;
 import org.commonjava.o11yphant.trace.spi.adapter.SpanAdapter;
 import org.commonjava.o11yphant.trace.spi.adapter.SpanContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 
-public class OtelSpanProvider implements SpanProvider
+public class OtelSpanProvider
+        implements SpanProvider
 {
+    private final Logger logger = LoggerFactory.getLogger( this.getClass() );
 
     private final Tracer tracer;
 
-    @SuppressWarnings("PMD")
+    @SuppressWarnings( "PMD" )
     public OtelSpanProvider( Tracer tracer )
     {
         this.tracer = tracer;
@@ -44,22 +48,19 @@ public class OtelSpanProvider implements SpanProvider
     public SpanAdapter startServiceRootSpan( String spanName, Optional<SpanContext> parentContext )
     {
         SpanBuilder spanBuilder = tracer.spanBuilder( spanName );
+        logger.trace( "Start a new server span {}", spanName );
         if ( parentContext.isPresent() )
         {
-            Context ctx = (( OtelSpanContext ) parentContext.get()).getContext();
-            spanBuilder.setParent( ctx);
+            Context ctx = ( (OtelSpanContext) parentContext.get() ).getContext();
+            logger.trace( "The span {} is using a parent context {}", spanName, ctx );
+            spanBuilder.setParent( ctx );
         }
         else
         {
             spanBuilder.setNoParent();
         }
 
-        Span span = spanBuilder.setSpanKind( SpanKind.SERVER ).startSpan();
-        //noinspection EmptyTryBlock
-        try (Scope ignored = span.makeCurrent())
-        {
-        }
-        return new OtelSpan( span, true );
+        return startSpan( spanBuilder, SpanKind.SERVER, true );
     }
 
     @Override
@@ -67,15 +68,18 @@ public class OtelSpanProvider implements SpanProvider
     {
         SpanBuilder spanBuilder = tracer.spanBuilder( spanName );
         boolean isRoot = true;
+        logger.trace( "Start a new child span {}", spanName );
         if ( parentContext.isPresent() )
         {
-            Context ctx = (( OtelSpanContext ) parentContext.get()).getContext();
-            spanBuilder.setParent( ctx);
+            Context ctx = ( (OtelSpanContext) parentContext.get() ).getContext();
+            spanBuilder.setParent( ctx );
+            logger.trace( "The span {} is using a parent context {}", spanName, ctx );
             isRoot = false;
         }
         else
         {
             Context ctx = Context.current();
+            logger.trace( "The span {} is using the current context {} as parent", spanName, ctx );
             if ( ctx != null )
             {
                 spanBuilder.setParent( ctx );
@@ -87,22 +91,31 @@ public class OtelSpanProvider implements SpanProvider
             }
         }
 
-        Span span = spanBuilder.setSpanKind( SpanKind.INTERNAL ).startSpan();
-        //noinspection EmptyTryBlock
-        try (Scope ignored = span.makeCurrent())
-        {
-        }
-        return new OtelSpan( span, isRoot );
+        return startSpan( spanBuilder, SpanKind.INTERNAL, isRoot );
     }
 
     @Override
     public SpanAdapter startClientSpan( String spanName )
     {
+        return startClientSpan( spanName, Optional.empty() );
+    }
+
+    @Override
+    public SpanAdapter startClientSpan( String spanName, Optional<SpanContext> parentContext )
+    {
         SpanBuilder spanBuilder = tracer.spanBuilder( spanName );
         Context ctx = Context.current();
+        if ( parentContext.isPresent() )
+        {
+            ctx = ( (OtelSpanContext) parentContext.get() ).getContext();
+            spanBuilder.setParent( ctx );
+            logger.trace( "The span {} is using a parent context {}", spanName, ctx );
+        }
         boolean localRoot = true;
+        logger.trace( "Start a new client span {}", spanName );
         if ( ctx != null )
         {
+            logger.trace( "The span {} is using a parent context {}", spanName, ctx );
             spanBuilder.setParent( ctx );
             localRoot = false;
         }
@@ -110,12 +123,17 @@ public class OtelSpanProvider implements SpanProvider
         {
             spanBuilder.setNoParent();
         }
+        return startSpan( spanBuilder, SpanKind.CLIENT, localRoot );
+    }
 
-        Span span = spanBuilder.setSpanKind( SpanKind.CLIENT ).startSpan();
-        //noinspection EmptyTryBlock
+    private OtelSpan startSpan( SpanBuilder builder, SpanKind kind, boolean isRoot )
+    {
+        Span span = builder.setSpanKind( kind ).startSpan();
         try (Scope ignored = span.makeCurrent())
         {
+            logger.trace( "span with id {} started in trace {}", span.getSpanContext().getSpanId(),
+                          span.getSpanContext().getTraceId() );
         }
-        return new OtelSpan( span, localRoot );
+        return new OtelSpan( span, isRoot );
     }
 }


### PR DESCRIPTION
   For a client span, sometimes it is created in the context from the
   root server span. We need to let it has propagation from the server
   root span. This PR will use the current active span as the context to
   propagate.